### PR TITLE
Kill query feature for admins + id->names in table

### DIFF
--- a/client/app/components/admin/RQStatus.jsx
+++ b/client/app/components/admin/RQStatus.jsx
@@ -6,7 +6,10 @@ import Badge from "antd/lib/badge";
 import Card from "antd/lib/card";
 import Spin from "antd/lib/spin";
 import Table from "antd/lib/table";
+import Button from 'antd/lib/button'
+import ThunderboltTwoTone from '@ant-design/icons/ThunderboltTwoTone'
 import { Columns } from "@/components/items-list/components/ItemsTable";
+import { axios } from "@/services/axios";
 
 // CounterCard
 
@@ -34,14 +37,55 @@ CounterCard.defaultProps = {
 // Tables
 
 const queryJobsColumns = [
-  { title: "Queue", dataIndex: "origin" },
-  { title: "Query ID", dataIndex: ["meta", "query_id"] },
-  { title: "Org ID", dataIndex: ["meta", "org_id"] },
-  { title: "Data Source ID", dataIndex: ["meta", "data_source_id"] },
-  { title: "User ID", dataIndex: ["meta", "user_id"] },
+  {
+    title: "Queue",
+    dataIndex: "origin"
+  },
+  {
+    title: "Query",
+    dataIndex: "query",
+    render: q => {
+      return (
+        <Button
+          shape="circle"
+          type="link"
+          href={`/queries/${q["id"]}/`}
+          target="_blank">
+          {q["name"]}
+        </Button>
+      )
+    }
+  },
+  {
+    title: "Org",
+    dataIndex: ["org", "name"]
+  },
+  {
+    title: "Data Source",
+    dataIndex: ["data_source", "name"]
+  },
+  {
+    title: "User",
+    dataIndex: ["user", "name"]
+  },
   Columns.custom(scheduled => scheduled.toString(), { title: "Scheduled", dataIndex: ["meta", "scheduled"] }),
   Columns.timeAgo({ title: "Start Time", dataIndex: "started_at" }),
   Columns.timeAgo({ title: "Enqueue Time", dataIndex: "enqueued_at" }),
+  {
+    title: "Kill Job",
+    dataIndex: "id",
+    render: j => {
+      return <Button
+        shape="circle"
+        size="large"
+        icon={<ThunderboltTwoTone twoToneColor="#f32013"/>}
+        onClick={e => {
+          axios.delete(`/api/jobs/${j}`)
+        }}
+      />
+    }
+
+  }
 ];
 
 const otherJobsColumns = [

--- a/redash/monitor.py
+++ b/redash/monitor.py
@@ -8,6 +8,7 @@ from redash.utils import json_loads
 from rq import Queue, Worker
 from rq.job import Job
 from rq.registry import StartedJobRegistry
+from redash import models
 
 
 def get_redis_status():
@@ -79,6 +80,22 @@ def fetch_jobs(job_ids):
             "enqueued_at": job.enqueued_at,
             "started_at": job.started_at,
             "meta": job.meta,
+            "data_source": {
+               "name": models.DataSource.get_by_id(job.meta["data_source_id"]).to_dict()["name"],
+               "id": job.meta["data_source_id"]
+            },
+            "query": {
+                "name": models.Query.get_by_id(job.meta["query_id"]).name,
+                "id": job.meta["query_id"]
+            },
+            "user":{
+                "name": models.User.get_by_id(job.meta["user_id"]).to_dict()["name"],
+                "id": job.meta["user_id"]
+            },
+            "org": {
+                "name": models.Organization.get_by_id(job.meta["org_id"]).name,
+                "id": job.meta["org_id"]
+            }
         }
         for job in Job.fetch_many(job_ids, connection=rq_redis_connection)
         if job is not None

--- a/redash/serializers/__init__.py
+++ b/redash/serializers/__init__.py
@@ -317,7 +317,7 @@ def serialize_job(job):
     result = query_result_id = None
 
     if job.is_cancelled:
-        error = "Query cancelled by user."
+        error = "Query cancelled. Contact an admin if this was not done by you."
         status = 4
     elif isinstance(job.result, Exception):
         error = str(job.result)


### PR DESCRIPTION
## Kill query feature for admins

**Changes** -
- Replaced all IDs with names.
- Query name is a link to the query itself.
- Added a Kill query button.
- Upon query cancellation, the message now always reads _Query canceled. Contact an admin if this was not done by you._ regardless of whether the query was canceled by the user or an admin.