### PR TITLE
Feature/data 552/disable show api key btn

### DIFF
--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -120,14 +120,7 @@ export default function QueryPageHeader({
             title: "Unpublish",
             onClick: unpublishQuery,
           },
-        },
-        {
-          showAPIKey: {
-            isAvailable: !clientConfig.disablePublicUrls && !queryFlags.isNew,
-            title: "Show API Key",
-            onClick: openApiKeyDialog,
-          },
-        },
+        }
       ]),
     [
       queryFlags.isNew,
@@ -142,7 +135,6 @@ export default function QueryPageHeader({
       isDesktop,
       publishQuery,
       unpublishQuery,
-      openApiKeyDialog,
     ]
   );
 

--- a/client/app/pages/queries/components/QueryPageHeader.jsx
+++ b/client/app/pages/queries/components/QueryPageHeader.jsx
@@ -120,7 +120,15 @@ export default function QueryPageHeader({
             title: "Unpublish",
             onClick: unpublishQuery,
           },
-        }
+        },
+        // DATA-552 - Disabled Show API Key button
+        // {
+        //   showAPIKey: {
+        //     isAvailable: !clientConfig.disablePublicUrls && !queryFlags.isNew,
+        //     title: "Show API Key",
+        //     onClick: openApiKeyDialog,
+        //   },
+        // },
       ]),
     [
       queryFlags.isNew,
@@ -135,6 +143,8 @@ export default function QueryPageHeader({
       isDesktop,
       publishQuery,
       unpublishQuery,
+      // DATA-552 - Disabled Show API Key button
+      // openApiKeyDialog,
     ]
   );
 

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -52,7 +52,7 @@ export class Query {
       this.options = {};
     }
     this.options.apply_auto_limit = !!this.options.apply_auto_limit;
-    this.options.apply_long_query = false;
+    this.options.apply_long_query = !!this.options.apply_long_query;
 
     if (!isArray(this.options.parameters)) {
       this.options.parameters = [];
@@ -422,7 +422,7 @@ QueryService.newQuery = function newQuery() {
     user: currentUser,
     options: {
       apply_auto_limit: localOptions.get("applyAutoLimit", true),
-      apply_long_query: localOptions.get("applyLongQuery", false)
+      apply_long_query: false
     },
     tags: [],
     can_edit: true,

--- a/client/app/services/query.js
+++ b/client/app/services/query.js
@@ -52,7 +52,7 @@ export class Query {
       this.options = {};
     }
     this.options.apply_auto_limit = !!this.options.apply_auto_limit;
-    this.options.apply_long_query = !!this.options.apply_long_query;
+    this.options.apply_long_query = false;
 
     if (!isArray(this.options.parameters)) {
       this.options.parameters = [];

--- a/requirements_bundles.txt
+++ b/requirements_bundles.txt
@@ -4,5 +4,5 @@
 # It's automatically installed when running npm run bundle
 
 # These can be removed when upgrading to Python 3.x
-importlib-metadata>=1.6  # remove when on 3.8
+importlib-metadata==4.13.0  # remove when on 3.8
 importlib_resources==1.5  # remove when on 3.9


### PR DESCRIPTION
## Data-552 / Disable show API key button
* Removed the Show API key button.
* Recent updates in `importlib-metadata` caused the application to break. Fixed the version to `4.13.0`.
* An old change of `Mark as a Long Query` checkbox defaulted to unchecked for new queries was never pushed. Added that in.